### PR TITLE
chore: add inheritedFrom

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -1,6 +1,6 @@
 /**
  * The top-level interface of a custom-elements.json file.
- * 
+ *
  * custom-elements.json documents all the elements in a single npm package,
  * across all modules within the package. Elements may be exported from multiple
  * modules with re-exports, but as a rule, elements in this file should be
@@ -35,7 +35,7 @@ export type ExportDoc = ClassDoc|FunctionDoc|VariableDoc;
 
 /**
  * A reference to an export of a module.
- * 
+ *
  * All references are required to be publically accessible, so the canonical
  * representation of a refernce it the export it's available from.
  */
@@ -88,6 +88,7 @@ export interface AttributeDoc {
    * The name of the field this attribute is associated with, if any.
    */
   fieldName?: string;
+  inheritedFrom?: Reference;
 }
 
 export interface EventDoc {
@@ -111,6 +112,7 @@ export interface EventDoc {
    * If the event is a CustomEvent, the type of `detail` field.
    */
   detailType?: string;
+  inheritedFrom?: Reference;
 }
 
 export interface SlotDoc {
@@ -165,12 +167,14 @@ export interface FieldDoc {
   description?: string;
   privacy?: Privacy;
   type?: string;
+  inheritedFrom?: Reference;
 }
 
 export interface MethodDoc extends FunctionLike {
   kind: 'method';
 
   static?: boolean;
+  inheritedFrom?: Reference;
 }
 
 /**


### PR DESCRIPTION
Should the `inheritedFrom` property be added anywhere else?