### PR TITLE
Chore/add definition doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-elements-json",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/schema.json
+++ b/schema.json
@@ -49,6 +49,30 @@
             ],
             "type": "object"
         },
+        "CustomElementDefinitionDoc": {
+            "properties": {
+                "declaration": {
+                    "$ref": "#/definitions/Reference",
+                    "description": "Reference to the class this custom element is registered with, and its module"
+                },
+                "kind": {
+                    "enum": [
+                        "definition"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Custom-element name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "declaration",
+                "kind",
+                "name"
+            ],
+            "type": "object"
+        },
         "FieldDoc": {
             "properties": {
                 "description": {
@@ -230,6 +254,9 @@
                             },
                             {
                                 "$ref": "#/definitions/VariableDoc"
+                            },
+                            {
+                                "$ref": "#/definitions/CustomElementDefinitionDoc"
                             }
                         ]
                     },
@@ -257,7 +284,7 @@
             "type": "string"
         },
         "Reference": {
-            "description": "A reference to an export of a module.\n\nAll references are required to be publically accessible, so the canonical\nrepresentation of a refernce it the export it's available from.",
+            "description": "A reference to an export of a module.\n\nAll references are required to be publically accessible, so the canonical\nrepresentation of a reference is the export it's available from.",
             "properties": {
                 "module": {
                     "type": "string"

--- a/schema.ts
+++ b/schema.ts
@@ -1,6 +1,6 @@
 /**
  * The top-level interface of a custom-elements.json file.
- * 
+ *
  * custom-elements.json documents all the elements in a single npm package,
  * across all modules within the package. Elements may be exported from multiple
  * modules with re-exports, but as a rule, elements in this file should be
@@ -31,13 +31,19 @@ export interface ModuleDoc {
   exports?: Array<ExportDoc>;
 }
 
-export type ExportDoc = ClassDoc|FunctionDoc|VariableDoc;
+export type ExportDoc = ClassDoc | FunctionDoc | VariableDoc | DefinitionDoc;
+
+export interface DefinitionDoc {
+  kind: string;
+  name: string;
+  declaration: Reference;
+}
 
 /**
  * A reference to an export of a module.
- * 
+ *
  * All references are required to be publically accessible, so the canonical
- * representation of a refernce it the export it's available from.
+ * representation of a reference is the export it's available from.
  */
 export interface Reference {
   name: string;

--- a/schema.ts
+++ b/schema.ts
@@ -31,11 +31,13 @@ export interface ModuleDoc {
   exports?: Array<ExportDoc>;
 }
 
-export type ExportDoc = ClassDoc | FunctionDoc | VariableDoc | DefinitionDoc;
+export type ExportDoc = ClassDoc | FunctionDoc | VariableDoc | CustomElementDefinitionDoc;
 
-export interface DefinitionDoc {
-  kind: string;
+export interface CustomElementDefinitionDoc {
+  kind: 'definition';
+  /** Custom-element name */
   name: string;
+  /** Reference to the class this custom element is registered with, and its module */
   declaration: Reference;
 }
 

--- a/schema.ts
+++ b/schema.ts
@@ -1,6 +1,6 @@
 /**
  * The top-level interface of a custom-elements.json file.
- * 
+ *
  * custom-elements.json documents all the elements in a single npm package,
  * across all modules within the package. Elements may be exported from multiple
  * modules with re-exports, but as a rule, elements in this file should be
@@ -35,7 +35,7 @@ export type ExportDoc = ClassDoc|FunctionDoc|VariableDoc;
 
 /**
  * A reference to an export of a module.
- * 
+ *
  * All references are required to be publically accessible, so the canonical
  * representation of a refernce it the export it's available from.
  */
@@ -88,6 +88,7 @@ export interface AttributeDoc {
    * The name of the field this attribute is associated with, if any.
    */
   fieldName?: string;
+  inheritedFrom?: Reference;
 }
 
 export interface EventDoc {
@@ -111,6 +112,7 @@ export interface EventDoc {
    * If the event is a CustomEvent, the type of `detail` field.
    */
   detailType?: string;
+  inheritedFrom?: Reference;
 }
 
 export interface SlotDoc {
@@ -165,12 +167,14 @@ export interface FieldDoc {
   description?: string;
   privacy?: Privacy;
   type?: string;
+  inheritedFrom?: Reference;
 }
 
 export interface MethodDoc extends FunctionLike {
   kind: 'method';
 
   static?: boolean;
+  inheritedFrom?: Reference;
 }
 
 /**

--- a/schema.ts
+++ b/schema.ts
@@ -1,6 +1,6 @@
 /**
  * The top-level interface of a custom-elements.json file.
- *
+ * 
  * custom-elements.json documents all the elements in a single npm package,
  * across all modules within the package. Elements may be exported from multiple
  * modules with re-exports, but as a rule, elements in this file should be
@@ -35,7 +35,7 @@ export type ExportDoc = ClassDoc|FunctionDoc|VariableDoc;
 
 /**
  * A reference to an export of a module.
- *
+ * 
  * All references are required to be publically accessible, so the canonical
  * representation of a refernce it the export it's available from.
  */
@@ -88,7 +88,6 @@ export interface AttributeDoc {
    * The name of the field this attribute is associated with, if any.
    */
   fieldName?: string;
-  inheritedFrom?: Reference;
 }
 
 export interface EventDoc {
@@ -112,7 +111,6 @@ export interface EventDoc {
    * If the event is a CustomEvent, the type of `detail` field.
    */
   detailType?: string;
-  inheritedFrom?: Reference;
 }
 
 export interface SlotDoc {
@@ -167,14 +165,12 @@ export interface FieldDoc {
   description?: string;
   privacy?: Privacy;
   type?: string;
-  inheritedFrom?: Reference;
 }
 
 export interface MethodDoc extends FunctionLike {
   kind: 'method';
 
   static?: boolean;
-  inheritedFrom?: Reference;
 }
 
 /**


### PR DESCRIPTION
Currently in the output of web component analyzer there is a `definition` export available:
```json
      "exports": [
        {
          "kind": "definition",
          "name": "a-a",
          "declaration": {
            "name": "A",
            "module": "./dev/src/custom-element/a-a.js"
          }
        },
      ]
```

Adding it to schema to keep things aligned